### PR TITLE
Add mapping for Milandia new sector images

### DIFF
--- a/backend-scripts/sector_img_mapping.csv
+++ b/backend-scripts/sector_img_mapping.csv
@@ -47,17 +47,15 @@
 806f103b097c9b1ae3b72db1c9682348.jpg,Gaswerk,Halle 5,Right Side,Top
 822459daaa9a4aff4562f81510ba915b.jpg,Gaswerk,Halle 3,Freiflug Marathon,Toppas Rechts
 84aee570a45dd8092f0ecab04336bba8.jpg,Gaswerk,Halle 3,Kinderwand
-859e1fe0315f79583df048b8de71efc9.jpg,Milandia,Boulder Blockfeld,Kleiner Block,Hall Side
+859e1fe0315f79583df048b8de71efc9.jpg,Milandia,Kinder Boulder,Kleiner Block
 8a435136f3ef346a3bca275d122be8f5.jpg,Milandia,Flower Tower,Window Side
 8b59d5de1cad61c63f97d6e999c0ff0a.jpg,Milandia,Boulder Blockfeld,Grosser Block,Hall Side
 8f0e0e5c060a926f075188a2f884004e.jpg,Gaswerk,Halle 1,Muschelwand
 91930d7f122843fae859e49f48fcb492.jpg,Gaswerk,Halle 2,Galerie,Gaswerkwand
 98923efd206fdf89f35441cc0bd26672.jpg,Gaswerk,Halle 3,Geneigte Platte
 9b329f8ababaaa9e99d25ba3c4a72ddf.jpg,Milandia,Spiderman
-9ca27e996c686912f167cdf75a9ddd80.jpg,Milandia,Boulder Blockfeld,Kleiner Block,Wall Side
 9e8726475a007ce241715f2927a0db0c.jpg,Gaswerk,Halle 4,Topropewand
 a409fa4e90d909fe33185d995eac4b46.jpg,Gaswerk,Outdoor,Aussenanlage
-a5e23e0ce06e7fe3b3c3fc5a72991b15.jpg,Milandia,Boulder Blockfeld,Kleiner Block,Window Side
 a6e62714030b0b7898fbc2580fdac462.jpg,Gaswerk,Outdoor,Nasenwand
 ab35b7ade0599f27ebe0c6f41027cf04.jpg,Gaswerk,Halle 2,Feuerwand
 ac1b01927dac9b61501efc5ac94c4293.jpg,Milandia,Boulder Blockfeld,Volumenwand,Right
@@ -83,11 +81,11 @@ e1916587c6f6670bb0e3ada0f6a775d9.jpg,Gaswerk,Halle 1,Old School,Right
 e1c9299be46fde6c94491794a09b03ad.jpg,Gaswerk,Outdoor,Arcowand
 e3c0dcb30e229b31b9c39fd025927658.jpg,Milandia,Boulder Tribüne,Left
 e47e0f0c806f6d0129280fac511d19a8.jpg,Milandia,Cerro Torre,Right
-e670f7fdab4fb1c956de0bd22b648ef5.jpg,Milandia,Boulder Blockfeld,Kleiner Block,Cafeteria Side
+e670f7fdab4fb1c956de0bd22b648ef5.jpg,Milandia,Kinder Boulder,Kleiner Block
 e90e4c8a080771d0028b7f753e46e45e.jpg,Milandia,Boulder Blockfeld,Volumenwand,Left
 efdcd9d8174b0c8d8c72928c4806d920.jpg,Milandia,Flower Tower,Wall Side
 f1f8d15f20752f95fe8be2f5ce7e085b.jpg,Milandia,Trango Tower,Hall Side
-f91382185cc93a7868c3b2e524deb2af.jpg,Milandia,Kinder Boulder
+f91382185cc93a7868c3b2e524deb2af.jpg,Milandia,Kinder Boulder,Wall
 f9af70e1090ebaeb5f1c94700847c925.jpg,Milandia,Sidewall
 fd2f0c551c008ed5b5d1b0d6e73211bc.jpg,Milandia,Trango Tower,Toppas Side
 ff5395a09131966a4ab88c88233577d6.jpg,Gaswerk,Halle 4,3D Wand,Left
@@ -148,3 +146,9 @@ e16a5cf707087acb30de7ed3f47f2b72.jpg,Wadenswil,Lieb es oder Lass es
 ec1d42d544e1571d6847cfc5922a42ae.jpg,Wadenswil,Leuchtturm
 f9aadfcae95168ed4cec4b79cd1f385a.jpg,Wadenswil,View Point
 fd1b62a88d844dcea4f3e6f1bf4761b4.jpg,Wadenswil,Romantik
+5922c7fbc61643d8519e9ce00677ef60.jpg,Milandia,Boulder Blockfeld,Volumenwand,Left
+0dc7dfaa9a73ab24a76d46d2bc35aeec.jpg,Milandia,Boulder Blockfeld,Volumenwand,Right
+a4bb4f210ccfee5bdb01925af62ff071.jpg,Milandia,Kinder Boulder,Kleiner Block
+98dfdc7df3e4e4db5a1df1e5a19b0cbd.jpg,Milandia,Kinder Boulder,Kleiner Block
+523e66102c0dda2d9ae4ac49367dfa1e.jpg,Milandia,Boulder Blockfeld,New Block,Bistro Side
+19a04a5c40bffb1400bba0904f26f4cd.jpg,Milandia,Milandia,Boulder Blockfeld,New Block,Window Side


### PR DESCRIPTION
- old images for Kleiner Block removed
- Kleiner Block mapping set to Kinder Boulder
- new images and mapping added for: Kleiner Block, New Block and Volumenwand